### PR TITLE
Update ELAN 2514 tablet definition

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -23,10 +23,14 @@
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/70
 
+# i2c:04f3:2b0a
+#
+# HP Envy x360 Convertible 15z-ee000
+
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817
+DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817;i2c:04f3:2b0a
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
Updated ELAN 2514 tablet definition to include 04f3:2b0a, the wacom layer for 15z-ee000 HP Envy x360 (2020)